### PR TITLE
Update currency formatting for total spent on movie tickets

### DIFF
--- a/themes/tickets/layouts/section/about.html
+++ b/themes/tickets/layouts/section/about.html
@@ -22,10 +22,12 @@ $totalItems }}
         average ticket price of
         <span class="highlight">${{ printf "%.2f" $averagePrice }}</span>. In
         total, I've currently spent roughly
-        <span class="highlight">${{ printf "%.2f" $totalSpent }}</span> on movie
-        tickets. While most tickets are from theaters in Marquette, Michigan,
-        this collection also includes stubs from screenings in far-off places
-        like <a href="/theaters/toho-cinemas-shinjuku/">Tokyo, Japan</a>,
+        <span class="highlight"
+          >{{ $totalSpent | lang.FormatCurrency 2 "USD" }}</span
+        >
+        on movie tickets. While most tickets are from theaters in Marquette,
+        Michigan, this collection also includes stubs from screenings in far-off
+        places like <a href="/theaters/toho-cinemas-shinjuku/">Tokyo, Japan</a>,
         <a href="/theaters/konsertpaleet/">Norway</a>, and
         <a href="/theaters/sambio-egilsholl/">Iceland</a>. Each ticket
         represents a unique cinematic moment, spanning genres, cultures, and


### PR DESCRIPTION
This pull request includes a change to the `themes/tickets/layouts/section/about.html` file to improve the formatting of currency values.

Formatting improvements:

* [`themes/tickets/layouts/section/about.html`](diffhunk://#diff-8db0daf67a15fd1185d8c30ac7ece4fe7dcc1f528d835dcb5b9c457141c6be85L25-R30): Changed the formatting of the `totalSpent` value to use the `lang.FormatCurrency` function for better readability and consistency.