### PR TITLE
Update HUGO_VERSION to 0.147.1

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
   command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.production.environment]
-  HUGO_VERSION = "0.141.0"
+  HUGO_VERSION = "0.147.1"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.141.0"
+  HUGO_VERSION = "0.147.1"


### PR DESCRIPTION
This pull request updates the Hugo version used in the Netlify deployment configuration to ensure compatibility with the latest features and bug fixes.

Deployment configuration updates:

* [`netlify.toml`](diffhunk://#diff-ab8f79b68b7adff7a07db953bf453f3c5aa6ade98d2b1b67d8432b36392489edL9-R12): Updated `HUGO_VERSION` from `0.141.0` to `0.147.1` in both the production and deploy-preview environments.