### PR TITLE
Add: Sinners ticket details

### DIFF
--- a/content/tickets/sinners-2.md
+++ b/content/tickets/sinners-2.md
@@ -1,0 +1,7 @@
+---
+title: "Sinners"
+date: "2025-05-02"
+price: "11.00"
+theaters: ["Marquette Cinemas"]
+ratings: ["R"]
+---


### PR DESCRIPTION
This pull request adds metadata for a new movie titled "Sinners" to the `content/tickets` directory. The metadata includes the title, release date, price, theaters, and ratings.

* Added a new markdown file `sinners-2.md` with the following metadata:
  - Title: "Sinners"
  - Release date: "2025-05-02"
  - Price: "$11.00"
  - Theaters: ["Marquette Cinemas"]
  - Ratings: ["R"]