### PR TITLE
Add: 28 Years Later ticket details

### DIFF
--- a/content/tickets/28-years-later.md
+++ b/content/tickets/28-years-later.md
@@ -1,0 +1,7 @@
+---
+title: "28 Years Later"
+date: "2025-06-20"
+price: "11.00"
+theaters: ["Marquette Cinemas"]
+ratings: ["R"]
+---


### PR DESCRIPTION
This pull request adds a new ticket entry for the movie "28 Years Later" to the `content/tickets` directory. 

Content addition:

* [`content/tickets/28-years-later.md`](diffhunk://#diff-a065fae95f4c7f6befd57bffb700b024fdf7f2c1d071e4f17a7649f4a5164553R1-R7): Created a new file with metadata including the title, release date, price, theater location, and ratings for the movie "28 Years Later."