### PR TITLE
Add: ticket details for "28 Years Later"

### DIFF
--- a/content/tickets/28-years-later-2.md
+++ b/content/tickets/28-years-later-2.md
@@ -1,0 +1,7 @@
+---
+title: "28 Years Later"
+date: "2025-06-23"
+price: "5.00"
+theaters: ["Marquette Cinemas"]
+ratings: ["R"]
+---

--- a/content/tickets/28-years-later-3.md
+++ b/content/tickets/28-years-later-3.md
@@ -1,0 +1,7 @@
+---
+title: "28 Years Later"
+date: "2025-06-26"
+price: "7.00"
+theaters: ["Marquette Cinemas"]
+ratings: ["R"]
+---


### PR DESCRIPTION
This pull request adds metadata for two new showings of the movie "28 Years Later" at Marquette Cinemas.

* Added metadata for the showing on June 23, 2025, priced at $5.00 (`content/tickets/28-years-later-2.md`).
* Added metadata for the showing on June 26, 2025, priced at $7.00 (`content/tickets/28-years-later-3.md`).