### PR TITLE
Update HUGO_VERSION to 0.148.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
   command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.production.environment]
-  HUGO_VERSION = "0.147.8"
+  HUGO_VERSION = "0.148.2"
 
 [context.deploy-preview.environment]
-  HUGO_VERSION = "0.147.8"
+  HUGO_VERSION = "0.148.2"


### PR DESCRIPTION
This pull request updates the Hugo version used in the Netlify deployment configuration to ensure the site builds with the latest features and fixes.

Deployment configuration:

* Updated the `HUGO_VERSION` environment variable from `0.147.8` to `0.148.2` for both production and deploy-preview contexts in `netlify.toml`.