### PR TITLE
Add: ticket details for "One Battle After Another"

### DIFF
--- a/content/tickets/one-battle-after-another.md
+++ b/content/tickets/one-battle-after-another.md
@@ -1,0 +1,7 @@
+---
+title: "One Battle After Another"
+date: "2025-09-28"
+price: "15.00"
+theaters: ["Marquette Cinemas"]
+ratings: ["R"]
+---


### PR DESCRIPTION
This pull request adds a new ticket entry for the film "One Battle After Another" to the content directory. The entry includes metadata such as title, release date, price, theater location, and rating.

Ticket metadata addition:

* [`content/tickets/one-battle-after-another.md`](diffhunk://#diff-c40feb9204e25dac1e8ab4b0827e77972d1f980defa5614df929d10be438209dR1-R7): Added a new markdown file with details for "One Battle After Another," including title, date, price, theater, and ratings.